### PR TITLE
Add multi-timeframe signal function

### DIFF
--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -15,7 +15,7 @@ The table below defines every field exported from the `RegimeFeature` struct. Al
 | dir | enum | Candle direction | `0`=DIR_NONE, `1`=DIR_BULL, `2`=DIR_BEAR | n/a | `1` | `GetCandleDirection` compares close vs. open price. |
 | session | enum | Market session context | `0`=SESSION_UNKNOWN, `1`=SESSION_ASIA, `2`=SESSION_EUROPE, `3`=SESSION_US | n/a | `3` | `GetMarketSession` derives the session from bar time hour. |
 | news_flag | bool | News event flag | `0` = false, `1` = true | n/a | `0` | `IsNewsEvent` placeholder to mark major economic news. |
-| mtf_signal | int | Multi time frame cross‑check signal | numeric code | n/a | `5` | Aggregated signal combining other timeframe indicators. |
+| mtf_signal | int | Multi time frame cross‑check signal | numeric code | n/a | `5` | Bitmask from H1 BOS, H1 trend, and M5 volume spike. |
 
 ## Sample Data
 

--- a/indicators/mtf_signal.mqh
+++ b/indicators/mtf_signal.mqh
@@ -9,8 +9,40 @@
 //+------------------------------------------------------------------+
 int GetMTFSignal(const MqlRates rates[], const int bars)
   {
-   // Placeholder logic - return zero for now so compilation succeeds
-   return(0);
+   //--- gather higher and lower timeframe data
+   MqlRates htf[];                     // H1 timeframe for broader trend/BOS
+   MqlRates ltf[];                     // M5 timeframe for volume confirmation
+
+   ArraySetAsSeries(htf,true);
+   ArraySetAsSeries(ltf,true);
+
+   // CopyRates returns number of elements copied; we request bars+1 to
+   // align index 0 with the latest bar across timeframes
+   int copied_htf = CopyRates(_Symbol,PERIOD_H1,0,bars+1,htf);
+   int copied_ltf = CopyRates(_Symbol,PERIOD_M5,0,bars+1,ltf);
+
+   // if history is missing fall back to neutral signal
+   if(copied_htf<=0 || copied_ltf<=0 || ArraySize(rates)<=bars)
+      return(0);
+
+   //--- indicator checks on different timeframes
+   bool bos_htf         = DetectBOS(htf,0);             // BOS on H1
+   TrendDirection dir   = GetTrendDirection(htf,bars);  // trend from H1
+   bool volume_spike_lf = DetectVolumeSpike(ltf,0);     // volume spike on M5
+
+   //--- combine results using a simple bit mask
+   // bit0 -> BOS detected on H1
+   // bit1 -> Uptrend on H1
+   // bit2 -> Volume spike on M5
+   int signal = 0;
+   if(bos_htf)
+      signal |= 1;
+   if(dir==TREND_UP)
+      signal |= 2;
+   if(volume_spike_lf)
+      signal |= 4;
+
+   return(signal);
   }
 
 #endif // MTF_SIGNAL_MQH


### PR DESCRIPTION
## Summary
- implement `GetMTFSignal` combining BOS/trend/volume across timeframes
- document new bitmask logic in data dictionary

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bf729c6808320889a461a67c8df92