### PR TITLE
Remove trailing comment

### DIFF
--- a/EA/features_struct.mqh
+++ b/EA/features_struct.mqh
@@ -109,11 +109,4 @@ void FeatureToCSV(const RegimeFeature &feature,string &csvRow)
             + IntegerToString(feature.mtf_signal);                 // Multi time frame signal
   }
 
-//+------------------------------------------------------------------+
-//| Convert RegimeFeature to CSV string                              |
-//| input:  feature - struct with calculated values                  |
-//| output: csvRow - string reference to receive CSV result          |
-//+------------------------------------------------------------------+
-
-
 #endif // FEATURES_STRUCT_MQH


### PR DESCRIPTION
## Summary
- clean up unused trailing comment at end of features_struct.mqh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfcea67008320b3a930992ad4b1b6