### PR TITLE
Handle history retrieval errors

### DIFF
--- a/EA/RegimeMasterEA.mq5
+++ b/EA/RegimeMasterEA.mq5
@@ -99,19 +99,39 @@ void ProcessBar(const int shift, RegimeFeature &feature)
    //--- gather required history arrays
   MqlRates rates[];
   ArraySetAsSeries(rates,true);
-  CopyRates(_Symbol,_Period,shift,50,rates);
+  int copied_rates = CopyRates(_Symbol,_Period,shift,50,rates);
+  if(copied_rates<=0)
+    {
+     PrintFormat("CopyRates failed for %s %s shift %d",_Symbol,_Period,shift);
+     return;
+    }
 
   //--- gather multi-timeframe history used for aggregation
   MqlRates htf[];
   MqlRates ltf[];
   ArraySetAsSeries(htf,true);
   ArraySetAsSeries(ltf,true);
-  CopyRates(_Symbol,PERIOD_H1,shift,50,htf);
-  CopyRates(_Symbol,PERIOD_M5,shift,50,ltf);
+  int copied_htf = CopyRates(_Symbol,PERIOD_H1,shift,50,htf);
+  if(copied_htf<=0)
+    {
+     PrintFormat("CopyRates failed for H1 shift %d",shift);
+     return;
+    }
+  int copied_ltf = CopyRates(_Symbol,PERIOD_M5,shift,50,ltf);
+  if(copied_ltf<=0)
+    {
+     PrintFormat("CopyRates failed for M5 shift %d",shift);
+     return;
+    }
 
   long volumes[];
   ArraySetAsSeries(volumes,true);
-  CopyTickVolume(_Symbol,_Period,shift,50,volumes);
+  int copied_vols = CopyTickVolume(_Symbol,_Period,shift,50,volumes);
+  if(copied_vols<=0)
+    {
+     PrintFormat("CopyTickVolume failed for shift %d",shift);
+     return;
+    }
 
    //--- populate a few core fields using indicator modules
    feature.bos          = DetectBOS(rates,0);              // break of structure

--- a/test/test_processbar_history.mq5
+++ b/test/test_processbar_history.mq5
@@ -1,0 +1,25 @@
+#include "..\\EA\\RegimeMasterEA.mq5"
+
+void AssertEqual(bool expected, bool actual, string message)
+  {
+   if(expected == actual)
+      Print("PASS: ", message);
+   else
+      PrintFormat("FAIL: %s expected=%d actual=%d", message, expected, actual);
+  }
+
+void TestProcessBarInsufficientHistory()
+  {
+   RegimeFeature feature;
+   // use large shift to simulate missing history
+   ProcessBar(99999, feature);
+   bool default_state = !feature.bos && feature.trend_dir==TREND_NONE && feature.mtf_signal==0;
+   AssertEqual(true, default_state, "ProcessBar early exit on missing history");
+  }
+
+int OnStart()
+  {
+   Print("Running ProcessBar history test");
+   TestProcessBarInsufficientHistory();
+   return(0);
+  }


### PR DESCRIPTION
## Summary
- detect failure when copying MT5 history
- exit `ProcessBar` early on data copy failure
- add unit test for missing history scenario

## Testing
- `pip install -r requirements.txt` *(fails: network access blocked)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfd82cbb4832091bd7d0f2b0a2aa4