### PR TITLE
Extend RegimeFeature with bar metadata

### DIFF
--- a/EA/ExportUtils.mqh
+++ b/EA/ExportUtils.mqh
@@ -66,6 +66,10 @@ void ExportFeatureJSON(const RegimeFeature &feature)
 //+------------------------------------------------------------------+
 bool ValidateFeature(const RegimeFeature &feature)
   {
+   if(feature.time<=0)
+      return(false);
+   if(StringLen(feature.symbol)==0)
+      return(false);
    if(feature.trend_dir < TREND_NONE || feature.trend_dir > TREND_DOWN)
       return(false);
    if(feature.candle_strength < STRENGTH_NONE || feature.candle_strength > STRENGTH_STRONG)
@@ -102,7 +106,7 @@ void ExportToCSV(RegimeFeature &features[], const string filename)
      FileSeek(handle,0,SEEK_END);
   else
      FileWrite(handle,
-               "bos,trend_dir,range_compression,volume_spike,divergent,"
+               "time,symbol,open,high,low,close,tick_volume,bos,trend_dir,range_compression,volume_spike,divergent,"
                "sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal");
 
    //--- iterate over feature array and output each struct as CSV row
@@ -113,6 +117,13 @@ void ExportToCSV(RegimeFeature &features[], const string filename)
 
       // write all fields as integer values in the defined order
       FileWrite(handle,
+                (int)f.time,
+                f.symbol,
+                DoubleToString(f.open,_Digits),
+                DoubleToString(f.high,_Digits),
+                DoubleToString(f.low,_Digits),
+                DoubleToString(f.close,_Digits),
+                (int)f.tick_volume,
                 (int)f.bos,
                 (int)f.trend_dir,
                 (int)f.range_compression,

--- a/EA/RegimeMasterEA.mq5
+++ b/EA/RegimeMasterEA.mq5
@@ -96,7 +96,7 @@ void ProcessBar(const int shift, RegimeFeature &feature)
    //--- reset all fields before calculation
    ResetRegimeFeature(feature);
 
-   //--- gather required history arrays
+  //--- gather required history arrays
   MqlRates rates[];
   ArraySetAsSeries(rates,true);
   int copied_rates = CopyRates(_Symbol,_Period,shift,50,rates);
@@ -105,6 +105,15 @@ void ProcessBar(const int shift, RegimeFeature &feature)
      PrintFormat("CopyRates failed for %s %s shift %d",_Symbol,_Period,shift);
      return;
     }
+
+  //--- basic bar info
+  feature.time        = rates[0].time;
+  feature.symbol      = _Symbol;
+  feature.open        = rates[0].open;
+  feature.high        = rates[0].high;
+  feature.low         = rates[0].low;
+  feature.close       = rates[0].close;
+  feature.tick_volume = rates[0].tick_volume;
 
   //--- gather multi-timeframe history used for aggregation
   MqlRates htf[];

--- a/EA/features_struct.mqh
+++ b/EA/features_struct.mqh
@@ -38,6 +38,13 @@ enum MarketSession
 //+------------------------------------------------------------------+
 struct RegimeFeature
   {
+   datetime       time;              // bar time
+   string         symbol;            // trading symbol
+   double         open;              // open price
+   double         high;              // high price
+   double         low;               // low price
+   double         close;             // close price
+   long           tick_volume;       // tick volume
    bool           bos;                // Break of Structure flag
    TrendDirection trend_dir;          // Trend direction enumeration
    bool           range_compression;  // Sideway compression/expansion flag
@@ -59,6 +66,14 @@ struct RegimeFeature
 //+------------------------------------------------------------------+
 void ResetRegimeFeature(RegimeFeature &feature)
   {
+   //--- reset time and price fields
+   feature.time        = 0;
+   feature.symbol      = "";
+   feature.open        = 0.0;
+   feature.high        = 0.0;
+   feature.low         = 0.0;
+   feature.close       = 0.0;
+   feature.tick_volume = 0;
    //--- clear boolean fields
    feature.bos              = false;           // reset Break of Structure flag
    feature.range_compression= false;           // reset compression/expansion flag
@@ -87,26 +102,34 @@ void FeatureToCSV(const RegimeFeature &feature,string &csvRow)
   {
    /*
       Serialize all struct fields into a comma separated string.
-      Each boolean or enumeration is cast to int so the CSV contains
+     Each boolean or enumeration is cast to int so the CSV contains
       only numeric values. Order of fields matches data_dictionary.md
       and ExportUtils.mqh:
+      time,symbol,open,high,low,close,tick_volume,
       bos,trend_dir,range_compression,volume_spike,divergent,
       sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal
-      Example row: "1,0,0,1,0,0,1,2,1,3,0,5".
+      Example row: "1623495600,EURUSD,1.1000,1.1050,1.0980,1.1020,150,1,0,0,1,0,0,1,2,1,3,0,5".
    */
 
-   csvRow  = IntegerToString((int)feature.bos)              + ","  // Break of Structure
-            + IntegerToString((int)feature.trend_dir)        + ","  // Trend direction
-            + IntegerToString((int)feature.range_compression)+ ","  // Range compression flag
-            + IntegerToString((int)feature.volume_spike)     + ","  // Volume spike confirmation
-            + IntegerToString((int)feature.divergent)        + ","  // Volume divergence
-            + IntegerToString((int)feature.sweep)            + ","  // Liquidity sweep
-            + IntegerToString((int)feature.ob_retest)        + ","  // Order Block retest
-            + IntegerToString((int)feature.candle_strength)  + ","  // Candle momentum strength
-            + IntegerToString((int)feature.dir)              + ","  // Candle direction
-            + IntegerToString((int)feature.session)          + ","  // Market session
-            + IntegerToString((int)feature.news_flag)        + ","  // News event flag
-            + IntegerToString(feature.mtf_signal);                 // Multi time frame signal
+   csvRow  = IntegerToString((int)feature.time)             + ","   // bar time
+            + feature.symbol                                + ","   // trading symbol
+            + DoubleToString(feature.open,_Digits)          + ","   // open price
+            + DoubleToString(feature.high,_Digits)          + ","   // high price
+            + DoubleToString(feature.low,_Digits)           + ","   // low price
+            + DoubleToString(feature.close,_Digits)         + ","   // close price
+            + IntegerToString((int)feature.tick_volume)     + ","   // tick volume
+            + IntegerToString((int)feature.bos)             + ","   // Break of Structure
+            + IntegerToString((int)feature.trend_dir)       + ","   // Trend direction
+            + IntegerToString((int)feature.range_compression)+ ","  // Range compression
+            + IntegerToString((int)feature.volume_spike)    + ","   // Volume spike
+            + IntegerToString((int)feature.divergent)       + ","   // Volume divergence
+            + IntegerToString((int)feature.sweep)           + ","   // Liquidity sweep
+            + IntegerToString((int)feature.ob_retest)       + ","   // Order Block retest
+            + IntegerToString((int)feature.candle_strength) + ","   // Candle momentum
+            + IntegerToString((int)feature.dir)             + ","   // Candle direction
+            + IntegerToString((int)feature.session)         + ","   // Market session
+            + IntegerToString((int)feature.news_flag)       + ","   // News flag
+            + IntegerToString(feature.mtf_signal);               // MTF signal
   }
 
 #endif // FEATURES_STRUCT_MQH

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ mt5_regime_detect/
 ทุก field ใน struct จะ auto-calc/logic-only, ไม่ manual (strict standard, no “feeling”)
 
 Layer	Field Name	Type	Description
+Meta    time,symbol,open,high,low,close,tick_volume datetime/string/num  Bar metadata from MqlRates
 Structure/Trend	bos, trend_dir	bool/enum	Break of Structure, Trend direction
 Range/Volatility	range_compression	bool	Detect sideway compression/expansion
 Volume	volume_spike, divergent	bool	Volume confirm, trap/flip

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -4,6 +4,13 @@ The table below defines every field exported from the `RegimeFeature` struct. Al
 
 | Field Name | Data Type | Description | Possible Values/Enum | Expected Range/Threshold | Example Value | Logic/Formula |
 | --- | --- | --- | --- | --- | --- | --- |
+| time | datetime | Bar time stamp | unix seconds | n/a | `1623495600` | `rates[0].time` value |
+| symbol | string | Trading symbol | e.g. `EURUSD` | n/a | `EURUSD` | `_Symbol` from MT5 |
+| open | double | Open price | n/a | n/a | `1.1000` | `rates[0].open` |
+| high | double | High price | n/a | n/a | `1.1050` | `rates[0].high` |
+| low | double | Low price | n/a | n/a | `1.0980` | `rates[0].low` |
+| close | double | Close price | n/a | n/a | `1.1020` | `rates[0].close` |
+| tick_volume | long | Tick volume | n/a | n/a | `150` | `rates[0].tick_volume` |
 | bos | bool | Break of Structure flag | `0` = false, `1` = true | n/a | `1` | `DetectBOS` compares current high/low with recent swings and returns true if either is broken. |
 | trend_dir | enum | Trend direction | `0`=TREND_NONE, `1`=TREND_UP, `2`=TREND_DOWN | n/a | `1` | `GetTrendDirection` checks the close price change over a lookback window. |
 | range_compression | bool | Sideway range compression detection | `0` = false, `1` = true | current range < 50% of lookback range | `0` | `DetectRangeCompression` compares current bar range to the max/min range over the window. |
@@ -21,20 +28,21 @@ The table below defines every field exported from the `RegimeFeature` struct. Al
 
 ### JSON
 ```json
-{"bos":1,"trend_dir":0,"range_compression":0,"volume_spike":1,"divergent":0,"sweep":0,"ob_retest":1,"candle_strength":2,"dir":1,"session":3,"news_flag":0,"mtf_signal":5}
-{"bos":0,"trend_dir":1,"range_compression":1,"volume_spike":0,"divergent":0,"sweep":0,"ob_retest":0,"candle_strength":1,"dir":2,"session":1,"news_flag":0,"mtf_signal":3}
-{"bos":0,"trend_dir":2,"range_compression":0,"volume_spike":0,"divergent":1,"sweep":1,"ob_retest":0,"candle_strength":0,"dir":0,"session":2,"news_flag":1,"mtf_signal":2}
+{"time":1623495600,"symbol":"EURUSD","open":1.1000,"high":1.1050,"low":1.0980,"close":1.1020,"tick_volume":150,"bos":1,"trend_dir":0,"range_compression":0,"volume_spike":1,"divergent":0,"sweep":0,"ob_retest":1,"candle_strength":2,"dir":1,"session":3,"news_flag":0,"mtf_signal":5}
+{"time":1623495660,"symbol":"EURUSD","open":1.1020,"high":1.1060,"low":1.0990,"close":1.1030,"tick_volume":120,"bos":0,"trend_dir":1,"range_compression":1,"volume_spike":0,"divergent":0,"sweep":0,"ob_retest":0,"candle_strength":1,"dir":2,"session":1,"news_flag":0,"mtf_signal":3}
+{"time":1623495720,"symbol":"EURUSD","open":1.1030,"high":1.1070,"low":1.1000,"close":1.1010,"tick_volume":130,"bos":0,"trend_dir":2,"range_compression":0,"volume_spike":0,"divergent":1,"sweep":1,"ob_retest":0,"candle_strength":0,"dir":0,"session":2,"news_flag":1,"mtf_signal":2}
 ```
 
 ### CSV
 ```
-bos,trend_dir,range_compression,volume_spike,divergent,sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal
-1,0,0,1,0,0,1,2,1,3,0,5
-0,1,1,0,0,0,0,1,2,1,0,3
-0,2,0,0,1,1,0,0,0,2,1,2
+time,symbol,open,high,low,close,tick_volume,bos,trend_dir,range_compression,volume_spike,divergent,sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal
+1623495600,EURUSD,1.1000,1.1050,1.0980,1.1020,150,1,0,0,1,0,0,1,2,1,3,0,5
+1623495660,EURUSD,1.1020,1.1060,1.0990,1.1030,120,0,1,1,0,0,0,0,1,2,1,0,3
+1623495720,EURUSD,1.1030,1.1070,1.1000,1.1010,130,0,2,0,0,1,1,0,0,0,2,1,2
 ```
 
 ## Field Version/Change Log
 | Date | Field Name | Change Description |
 | --- | --- | --- |
 | 2025-06-13 | RegimeFeature struct | Initial implementation of all fields and indicator logic. |
+| 2025-06-14 | Added price metadata | Added time, symbol, OHLC and tick_volume fields. |


### PR DESCRIPTION
## Summary
- expand `RegimeFeature` to store bar metadata and OHLCV
- reset and export these new fields
- fill metadata inside `ProcessBar`
- update CSV export header/order
- document new columns in the data dictionary and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ceef0ead483209f39ef9b405ebdda