### PR TITLE
Implement regime classification

### DIFF
--- a/EA/ExportUtils.mqh
+++ b/EA/ExportUtils.mqh
@@ -40,7 +40,7 @@ void ExportFeatureCSV(const RegimeFeature &feature)
 //+------------------------------------------------------------------+
 void ExportFeatureJSON(const RegimeFeature &feature)
   {
-   string json=StringFormat("{\"bos\":%d,\"trend_dir\":%d,\"range_compression\":%d,\"volume_spike\":%d,\"divergent\":%d,\"sweep\":%d,\"ob_retest\":%d,\"candle_strength\":%d,\"dir\":%d,\"session\":%d,\"news_flag\":%d,\"mtf_signal\":%d}",
+   string json=StringFormat("{\"bos\":%d,\"trend_dir\":%d,\"range_compression\":%d,\"volume_spike\":%d,\"divergent\":%d,\"sweep\":%d,\"ob_retest\":%d,\"candle_strength\":%d,\"dir\":%d,\"session\":%d,\"news_flag\":%d,\"mtf_signal\":%d,\"regime\":%d}",
                            (int)feature.bos,
                            (int)feature.trend_dir,
                            (int)feature.range_compression,
@@ -52,7 +52,8 @@ void ExportFeatureJSON(const RegimeFeature &feature)
                            (int)feature.dir,
                            (int)feature.session,
                            (int)feature.news_flag,
-                           feature.mtf_signal);
+                           feature.mtf_signal,
+                           (int)feature.regime);
    int handle=FileOpen("data\\exported_features.json",FILE_WRITE|FILE_TXT|FILE_ANSI|FILE_APPEND);
    if(handle!=INVALID_HANDLE)
      {
@@ -76,10 +77,12 @@ bool ValidateFeature(const RegimeFeature &feature)
       return(false);
    if(feature.dir < DIR_NONE || feature.dir > DIR_BEAR)
       return(false);
-   if(feature.session < SESSION_UNKNOWN || feature.session > SESSION_US)
+  if(feature.session < SESSION_UNKNOWN || feature.session > SESSION_US)
+     return(false);
+   if(feature.regime < REGIME_UPTREND || feature.regime > REGIME_UNKNOWN)
       return(false);
-   return(true);
-  }
+  return(true);
+ }
 
 //+------------------------------------------------------------------+
 //| Export array of RegimeFeature structs to CSV file                |
@@ -90,7 +93,7 @@ bool ValidateFeature(const RegimeFeature &feature)
 //| The CSV format uses a header row followed by numeric values.     |
 //| Existing files are not overwritten. New rows are appended to the |
 //| end so historical data is preserved.                             |
-//| Sample row: "1,0,0,1,0,0,1,2,1,3,0,5"                            |
+//| Sample row: "1,0,0,1,0,0,1,2,1,3,0,5,0"                           |
 //+------------------------------------------------------------------+
 void ExportToCSV(RegimeFeature &features[], const string filename)
   {
@@ -105,9 +108,9 @@ void ExportToCSV(RegimeFeature &features[], const string filename)
   if(exists)
      FileSeek(handle,0,SEEK_END);
   else
-     FileWrite(handle,
+    FileWrite(handle,
                "time,symbol,open,high,low,close,tick_volume,bos,trend_dir,range_compression,volume_spike,divergent,"
-               "sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal");
+               "sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal,regime");
 
    //--- iterate over feature array and output each struct as CSV row
    int total = ArraySize(features);
@@ -135,7 +138,8 @@ void ExportToCSV(RegimeFeature &features[], const string filename)
                 (int)f.dir,
                 (int)f.session,
                 (int)f.news_flag,
-                f.mtf_signal);
+                f.mtf_signal,
+                (int)f.regime);
      }
 
    //--- close the file after writing all rows

--- a/EA/RegimeMasterEA.mq5
+++ b/EA/RegimeMasterEA.mq5
@@ -9,6 +9,7 @@
 
 #include "..\indicators\mtf_signal.mqh"        // Multi time frame signal
 #include "..\indicators\mtf_tools.mqh"         // Aggregation helpers for MTF
+#include "..\indicators\regime_classifier.mqh" // Regime classification logic
 //+------------------------------------------------------------------+
 //| Constants and global storage                                     |
 //+------------------------------------------------------------------+
@@ -156,6 +157,7 @@ void ProcessBar(const int shift, RegimeFeature &feature)
    feature.dir              = GetCandleDirection(rates,0);                 // candle direction
    feature.news_flag        = IsNewsEvent(rates[shift].time);              // flag news events
    feature.mtf_signal       = AggregateMTFSignal(htf,ltf,HISTORY_BARS);    // multi time frame signal
+   feature.regime           = DetectRegime(feature);                       // classify regime
   }
 
 //+------------------------------------------------------------------+

--- a/EA/features_struct.mqh
+++ b/EA/features_struct.mqh
@@ -33,6 +33,19 @@ enum MarketSession
    SESSION_US
   };
 
+enum RegimeType
+  {
+   REGIME_UPTREND = 0,
+   REGIME_DOWNTREND,
+   REGIME_STABLE_RANGE,
+   REGIME_VOLATILE_RANGE,
+   REGIME_BREAKOUT,
+   REGIME_TRAP,
+   REGIME_DRIFT,
+   REGIME_CHAOS,
+   REGIME_UNKNOWN
+  };
+
 //+------------------------------------------------------------------+
 //| Structure storing regime detection features                      |
 //+------------------------------------------------------------------+
@@ -55,8 +68,9 @@ struct RegimeFeature
    CandleStrength candle_strength;    // Candle momentum strength
    CandleDirection dir;               // Candle direction
    MarketSession  session;            // Market session context
-   bool           news_flag;          // News event flag
-   int            mtf_signal;         // Multi time frame cross-check signal
+  bool           news_flag;          // News event flag
+  int            mtf_signal;         // Multi time frame cross-check signal
+  RegimeType     regime;             // Classified regime type
   };
 
 //+------------------------------------------------------------------+
@@ -91,6 +105,7 @@ void ResetRegimeFeature(RegimeFeature &feature)
 
    //--- reset numeric fields
    feature.mtf_signal       = 0;               // reset multi time frame signal
+   feature.regime           = REGIME_UNKNOWN;  // reset regime classification
   }
 
 //+------------------------------------------------------------------+
@@ -107,8 +122,8 @@ void FeatureToCSV(const RegimeFeature &feature,string &csvRow)
       and ExportUtils.mqh:
       time,symbol,open,high,low,close,tick_volume,
       bos,trend_dir,range_compression,volume_spike,divergent,
-      sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal
-      Example row: "1623495600,EURUSD,1.1000,1.1050,1.0980,1.1020,150,1,0,0,1,0,0,1,2,1,3,0,5".
+      sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal,regime
+      Example row: "1623495600,EURUSD,1.1000,1.1050,1.0980,1.1020,150,1,0,0,1,0,0,1,2,1,3,0,5,0".
    */
 
    csvRow  = IntegerToString((int)feature.time)             + ","   // bar time
@@ -129,7 +144,8 @@ void FeatureToCSV(const RegimeFeature &feature,string &csvRow)
             + IntegerToString((int)feature.dir)             + ","   // Candle direction
             + IntegerToString((int)feature.session)         + ","   // Market session
             + IntegerToString((int)feature.news_flag)       + ","   // News flag
-            + IntegerToString(feature.mtf_signal);               // MTF signal
+            + IntegerToString(feature.mtf_signal)           + ","   // MTF signal
+            + IntegerToString((int)feature.regime);             // Regime type
   }
 
 #endif // FEATURES_STRUCT_MQH

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ mt5_regime_detect/
 │   ├── volume_tools.mqh             # logic volume spike/divergent
 │   ├── ob_retest.mqh                # logic OB retest/trap
 │   ├── candle_momentum.mqh          # logic candle strength/direction
-│   └── session_tools.mqh            # logic session/context
+│   ├── session_tools.mqh            # logic session/context
+│   └── regime_classifier.mqh        # classify market regime
 ├── data/
 │   ├── exported_features.csv        # ไฟล์ export dataset
 ├── test/
@@ -66,7 +67,9 @@ OB Retest/Trap	ob_retest	bool	เจาะจงโซน trap/fake move
 Candle/Momentum	candle_strength, dir	enum	Momentum strength/direction
 Session/Context	session, news_flag	enum/bool	Market session/context/news flag
 Multi-TF	mtf_signal	dict/obj	Cross-check หลาย TF
+Classification  regime          enum    Result from DetectRegime
 
+DetectRegime evaluates features and sets `regime` (UPTREND,DOWNTREND,etc.)
 Data Dictionary, format, and logic—reference in /docs/data_dictionary.md
 
 🔁 Workflow Summary

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -23,22 +23,23 @@ The table below defines every field exported from the `RegimeFeature` struct. Al
 | session | enum | Market session context | `0`=SESSION_UNKNOWN, `1`=SESSION_ASIA, `2`=SESSION_EUROPE, `3`=SESSION_US | n/a | `3` | `GetMarketSession` derives the session from bar time hour. |
 | news_flag | bool | News event flag | `0` = false, `1` = true | n/a | `0` | `IsNewsEvent` placeholder to mark major economic news. |
 | mtf_signal | int | Multi time frame cross‑check signal | numeric code | n/a | `5` | Bitmask from H1 BOS, H1 trend, and M5 volume spike. |
+| regime | enum | Classified market regime | `0`=REGIME_UPTREND, `1`=REGIME_DOWNTREND, `2`=REGIME_STABLE_RANGE, `3`=REGIME_VOLATILE_RANGE, `4`=REGIME_BREAKOUT, `5`=REGIME_TRAP, `6`=REGIME_DRIFT, `7`=REGIME_CHAOS, `8`=REGIME_UNKNOWN | n/a | `0` | `DetectRegime` evaluation of other fields. |
 
 ## Sample Data
 
 ### JSON
 ```json
-{"time":1623495600,"symbol":"EURUSD","open":1.1000,"high":1.1050,"low":1.0980,"close":1.1020,"tick_volume":150,"bos":1,"trend_dir":0,"range_compression":0,"volume_spike":1,"divergent":0,"sweep":0,"ob_retest":1,"candle_strength":2,"dir":1,"session":3,"news_flag":0,"mtf_signal":5}
-{"time":1623495660,"symbol":"EURUSD","open":1.1020,"high":1.1060,"low":1.0990,"close":1.1030,"tick_volume":120,"bos":0,"trend_dir":1,"range_compression":1,"volume_spike":0,"divergent":0,"sweep":0,"ob_retest":0,"candle_strength":1,"dir":2,"session":1,"news_flag":0,"mtf_signal":3}
-{"time":1623495720,"symbol":"EURUSD","open":1.1030,"high":1.1070,"low":1.1000,"close":1.1010,"tick_volume":130,"bos":0,"trend_dir":2,"range_compression":0,"volume_spike":0,"divergent":1,"sweep":1,"ob_retest":0,"candle_strength":0,"dir":0,"session":2,"news_flag":1,"mtf_signal":2}
+{"time":1623495600,"symbol":"EURUSD","open":1.1000,"high":1.1050,"low":1.0980,"close":1.1020,"tick_volume":150,"bos":1,"trend_dir":0,"range_compression":0,"volume_spike":1,"divergent":0,"sweep":0,"ob_retest":1,"candle_strength":2,"dir":1,"session":3,"news_flag":0,"mtf_signal":5,"regime":0}
+{"time":1623495660,"symbol":"EURUSD","open":1.1020,"high":1.1060,"low":1.0990,"close":1.1030,"tick_volume":120,"bos":0,"trend_dir":1,"range_compression":1,"volume_spike":0,"divergent":0,"sweep":0,"ob_retest":0,"candle_strength":1,"dir":2,"session":1,"news_flag":0,"mtf_signal":3,"regime":2}
+{"time":1623495720,"symbol":"EURUSD","open":1.1030,"high":1.1070,"low":1.1000,"close":1.1010,"tick_volume":130,"bos":0,"trend_dir":2,"range_compression":0,"volume_spike":0,"divergent":1,"sweep":1,"ob_retest":0,"candle_strength":0,"dir":0,"session":2,"news_flag":1,"mtf_signal":2,"regime":8}
 ```
 
 ### CSV
 ```
-time,symbol,open,high,low,close,tick_volume,bos,trend_dir,range_compression,volume_spike,divergent,sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal
-1623495600,EURUSD,1.1000,1.1050,1.0980,1.1020,150,1,0,0,1,0,0,1,2,1,3,0,5
-1623495660,EURUSD,1.1020,1.1060,1.0990,1.1030,120,0,1,1,0,0,0,0,1,2,1,0,3
-1623495720,EURUSD,1.1030,1.1070,1.1000,1.1010,130,0,2,0,0,1,1,0,0,0,2,1,2
+time,symbol,open,high,low,close,tick_volume,bos,trend_dir,range_compression,volume_spike,divergent,sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal,regime
+1623495600,EURUSD,1.1000,1.1050,1.0980,1.1020,150,1,0,0,1,0,0,1,2,1,3,0,5,0
+1623495660,EURUSD,1.1020,1.1060,1.0990,1.1030,120,0,1,1,0,0,0,0,1,2,1,0,3,2
+1623495720,EURUSD,1.1030,1.1070,1.1000,1.1010,130,0,2,0,0,1,1,0,0,0,2,1,2,8
 ```
 
 ## Field Version/Change Log
@@ -46,3 +47,4 @@ time,symbol,open,high,low,close,tick_volume,bos,trend_dir,range_compression,volu
 | --- | --- | --- |
 | 2025-06-13 | RegimeFeature struct | Initial implementation of all fields and indicator logic. |
 | 2025-06-14 | Added price metadata | Added time, symbol, OHLC and tick_volume fields. |
+| 2025-06-15 | regime | Added regime classification field and DetectRegime logic. |

--- a/docs/logic_note.md
+++ b/docs/logic_note.md
@@ -44,6 +44,22 @@ The final signal is a bit mask where multiple conditions may be active simultane
 
 Uses the built‑in economic calendar to detect high importance events within ±30 minutes of the bar time. Returns **true** when at least one such event is found for the symbol's base currency.
 
+### Regime Classification
+
+`DetectRegime` maps the calculated features to a `RegimeType` enum:
+
+| Regime | Rule |
+| --- | --- |
+| `REGIME_UPTREND` | `trend_dir` = TREND_UP and not `range_compression` |
+| `REGIME_DOWNTREND` | `trend_dir` = TREND_DOWN and not `range_compression` |
+| `REGIME_STABLE_RANGE` | `range_compression` = true and `volume_spike` = false |
+| `REGIME_VOLATILE_RANGE` | `range_compression` = true and `volume_spike` = true |
+| `REGIME_BREAKOUT` | `bos` = true and `sweep` = false |
+| `REGIME_TRAP` | `ob_retest` = true |
+| `REGIME_DRIFT` | no momentum, no volume spike and `trend_dir` = TREND_NONE |
+| `REGIME_CHAOS` | `bos`, `sweep` and `volume_spike` all true |
+| `REGIME_UNKNOWN` | none of the above conditions |
+
 ## EA Workflow
 
 1. **Initialization (`OnInit`)**

--- a/indicators/regime_classifier.mqh
+++ b/indicators/regime_classifier.mqh
@@ -1,0 +1,32 @@
+#ifndef REGIME_CLASSIFIER_MQH
+#define REGIME_CLASSIFIER_MQH
+
+#include "..\\EA\\features_struct.mqh"
+
+//+------------------------------------------------------------------+
+//| Classify current market regime based on feature values            |
+//| input:  feature - calculated RegimeFeature                        |
+//| output: RegimeType enumeration value                              |
+//+------------------------------------------------------------------+
+RegimeType DetectRegime(const RegimeFeature &feature)
+  {
+   if(feature.ob_retest)
+      return(REGIME_TRAP);
+   if(feature.bos && feature.sweep && feature.volume_spike)
+      return(REGIME_CHAOS);
+   if(feature.bos && !feature.sweep)
+      return(REGIME_BREAKOUT);
+   if(feature.range_compression && feature.volume_spike)
+      return(REGIME_VOLATILE_RANGE);
+   if(feature.range_compression && !feature.volume_spike)
+      return(REGIME_STABLE_RANGE);
+   if(feature.trend_dir==TREND_UP && !feature.range_compression)
+      return(REGIME_UPTREND);
+   if(feature.trend_dir==TREND_DOWN && !feature.range_compression)
+      return(REGIME_DOWNTREND);
+   if(feature.candle_strength==STRENGTH_NONE && !feature.volume_spike && feature.trend_dir==TREND_NONE)
+      return(REGIME_DRIFT);
+   return(REGIME_UNKNOWN);
+  }
+
+#endif // REGIME_CLASSIFIER_MQH

--- a/test/test_regime_classifier.mq5
+++ b/test/test_regime_classifier.mq5
@@ -1,0 +1,74 @@
+#include "..\\EA\\features_struct.mqh"
+#include "..\\indicators\\regime_classifier.mqh"
+
+void AssertEqual(int expected,int actual,string message)
+  {
+   if(expected==actual)
+      Print("PASS: ",message);
+   else
+      PrintFormat("FAIL: %s expected=%d actual=%d",message,expected,actual);
+  }
+
+void TestDetectRegime()
+  {
+   RegimeFeature f;
+   ResetRegimeFeature(f);
+
+   // uptrend
+   f.trend_dir=TREND_UP;
+   f.range_compression=false;
+   AssertEqual(REGIME_UPTREND,DetectRegime(f),"DetectRegime uptrend");
+
+   // downtrend
+   ResetRegimeFeature(f);
+   f.trend_dir=TREND_DOWN;
+   AssertEqual(REGIME_DOWNTREND,DetectRegime(f),"DetectRegime downtrend");
+
+   // stable range
+   ResetRegimeFeature(f);
+   f.range_compression=true;
+   f.volume_spike=false;
+   AssertEqual(REGIME_STABLE_RANGE,DetectRegime(f),"DetectRegime stable range");
+
+   // volatile range
+   ResetRegimeFeature(f);
+   f.range_compression=true;
+   f.volume_spike=true;
+   AssertEqual(REGIME_VOLATILE_RANGE,DetectRegime(f),"DetectRegime volatile range");
+
+   // breakout
+   ResetRegimeFeature(f);
+   f.bos=true;
+   f.sweep=false;
+   AssertEqual(REGIME_BREAKOUT,DetectRegime(f),"DetectRegime breakout");
+
+   // trap
+   ResetRegimeFeature(f);
+   f.ob_retest=true;
+   AssertEqual(REGIME_TRAP,DetectRegime(f),"DetectRegime trap");
+
+   // drift
+   ResetRegimeFeature(f);
+   f.trend_dir=TREND_NONE;
+   f.candle_strength=STRENGTH_NONE;
+   f.volume_spike=false;
+   AssertEqual(REGIME_DRIFT,DetectRegime(f),"DetectRegime drift");
+
+   // chaos
+   ResetRegimeFeature(f);
+   f.bos=true;
+   f.sweep=true;
+   f.volume_spike=true;
+   AssertEqual(REGIME_CHAOS,DetectRegime(f),"DetectRegime chaos");
+
+   // unknown
+   ResetRegimeFeature(f);
+   AssertEqual(REGIME_UNKNOWN,DetectRegime(f),"DetectRegime unknown");
+  }
+
+int OnStart()
+  {
+   Print("Running regime classifier tests");
+   TestDetectRegime();
+   return(0);
+  }


### PR DESCRIPTION
## Summary
- define `RegimeType` enum and add `regime` field
- implement `DetectRegime` classifier
- update CSV/JSON export logic and struct reset
- include regime logic in EA process flow
- document classification rules in docs and README
- add unit tests for `DetectRegime`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf012a6b08320bd922089c239de83