### PR TITLE
Add volatility indicators and update regime logic

### DIFF
--- a/EA/ExportUtils.mqh
+++ b/EA/ExportUtils.mqh
@@ -109,7 +109,7 @@ void ExportToCSV(RegimeFeature &features[], const string filename)
      FileSeek(handle,0,SEEK_END);
   else
     FileWrite(handle,
-               "time,symbol,open,high,low,close,tick_volume,bos,trend_dir,range_compression,volume_spike,divergent,"
+               "time,symbol,open,high,low,close,tick_volume,atr,stddev,ma_slope,rsi,bos,trend_dir,range_compression,volume_spike,divergent,"
                "sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal,regime");
 
    //--- iterate over feature array and output each struct as CSV row
@@ -127,6 +127,10 @@ void ExportToCSV(RegimeFeature &features[], const string filename)
                 DoubleToString(f.low,_Digits),
                 DoubleToString(f.close,_Digits),
                 (int)f.tick_volume,
+                DoubleToString(f.atr,_Digits),
+                DoubleToString(f.stddev,_Digits),
+                DoubleToString(f.ma_slope,_Digits),
+                DoubleToString(f.rsi,_Digits),
                 (int)f.bos,
                 (int)f.trend_dir,
                 (int)f.range_compression,

--- a/EA/RegimeMasterEA.mq5
+++ b/EA/RegimeMasterEA.mq5
@@ -6,6 +6,9 @@
 #include "..\indicators\ob_retest.mqh"        // Order Block retest detector
 #include "..\indicators\candle_momentum.mqh"  // Candle strength/direction tools
 #include "..\indicators\session_tools.mqh"    // Session and news utilities
+#include "..\indicators\atr_tools.mqh"        // ATR and StdDev calculations
+#include "..\indicators\ma_slope.mqh"        // Moving average slope
+#include "..\indicators\rsi_tools.mqh"       // RSI indicator
 
 #include "..\indicators\mtf_signal.mqh"        // Multi time frame signal
 #include "..\indicators\mtf_tools.mqh"         // Aggregation helpers for MTF
@@ -142,6 +145,12 @@ void ProcessBar(const int shift, RegimeFeature &feature)
      PrintFormat("CopyTickVolume failed for shift %d",shift);
      return;
     }
+
+  //--- volatility and momentum indicators
+  feature.atr      = CalcATR(rates,14);
+  feature.stddev   = CalcStdDev(rates,14);
+  feature.ma_slope = GetMASlope(rates,10);
+  feature.rsi      = GetRSI(rates,14);
 
    //--- populate a few core fields using indicator modules
    feature.bos          = DetectBOS(rates,0);              // break of structure

--- a/EA/features_struct.mqh
+++ b/EA/features_struct.mqh
@@ -58,6 +58,10 @@ struct RegimeFeature
    double         low;               // low price
    double         close;             // close price
    long           tick_volume;       // tick volume
+   double         atr;               // Average True Range
+   double         stddev;            // Price standard deviation
+   double         ma_slope;          // Moving average slope
+   double         rsi;               // Relative Strength Index
    bool           bos;                // Break of Structure flag
    TrendDirection trend_dir;          // Trend direction enumeration
    bool           range_compression;  // Sideway compression/expansion flag
@@ -86,8 +90,12 @@ void ResetRegimeFeature(RegimeFeature &feature)
    feature.open        = 0.0;
    feature.high        = 0.0;
    feature.low         = 0.0;
-   feature.close       = 0.0;
-   feature.tick_volume = 0;
+  feature.close       = 0.0;
+  feature.tick_volume = 0;
+  feature.atr         = 0.0;
+  feature.stddev      = 0.0;
+  feature.ma_slope    = 0.0;
+  feature.rsi         = 0.0;
    //--- clear boolean fields
    feature.bos              = false;           // reset Break of Structure flag
    feature.range_compression= false;           // reset compression/expansion flag
@@ -120,7 +128,7 @@ void FeatureToCSV(const RegimeFeature &feature,string &csvRow)
      Each boolean or enumeration is cast to int so the CSV contains
       only numeric values. Order of fields matches data_dictionary.md
       and ExportUtils.mqh:
-      time,symbol,open,high,low,close,tick_volume,
+      time,symbol,open,high,low,close,tick_volume,atr,stddev,ma_slope,rsi,
       bos,trend_dir,range_compression,volume_spike,divergent,
       sweep,ob_retest,candle_strength,dir,session,news_flag,mtf_signal,regime
       Example row: "1623495600,EURUSD,1.1000,1.1050,1.0980,1.1020,150,1,0,0,1,0,0,1,2,1,3,0,5,0".
@@ -133,6 +141,10 @@ void FeatureToCSV(const RegimeFeature &feature,string &csvRow)
             + DoubleToString(feature.low,_Digits)           + ","   // low price
             + DoubleToString(feature.close,_Digits)         + ","   // close price
             + IntegerToString((int)feature.tick_volume)     + ","   // tick volume
+            + DoubleToString(feature.atr,_Digits)           + ","   // ATR
+            + DoubleToString(feature.stddev,_Digits)        + ","   // StdDev
+            + DoubleToString(feature.ma_slope,_Digits)      + ","   // MA slope
+            + DoubleToString(feature.rsi,_Digits)           + ","   // RSI
             + IntegerToString((int)feature.bos)             + ","   // Break of Structure
             + IntegerToString((int)feature.trend_dir)       + ","   // Trend direction
             + IntegerToString((int)feature.range_compression)+ ","  // Range compression

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ mt5_regime_detect/
 │   ├── ob_retest.mqh                # logic OB retest/trap
 │   ├── candle_momentum.mqh          # logic candle strength/direction
 │   ├── session_tools.mqh            # logic session/context
+│   ├── atr_tools.mqh                # ATR & StdDev calculations
+│   ├── ma_slope.mqh                 # moving average slope
+│   ├── rsi_tools.mqh                # RSI indicator
 │   └── regime_classifier.mqh        # classify market regime
 ├── data/
 │   ├── exported_features.csv        # ไฟล์ export dataset
@@ -58,7 +61,7 @@ mt5_regime_detect/
 ทุก field ใน struct จะ auto-calc/logic-only, ไม่ manual (strict standard, no “feeling”)
 
 Layer	Field Name	Type	Description
-Meta    time,symbol,open,high,low,close,tick_volume datetime/string/num  Bar metadata from MqlRates
+Meta    time,symbol,open,high,low,close,tick_volume,atr,stddev,ma_slope,rsi datetime/string/num  Bar metadata + volatility metrics
 Structure/Trend	bos, trend_dir	bool/enum	Break of Structure, Trend direction
 Range/Volatility	range_compression	bool	Detect sideway compression/expansion
 Volume	volume_spike, divergent	bool	Volume confirm, trap/flip

--- a/indicators/atr_tools.mqh
+++ b/indicators/atr_tools.mqh
@@ -1,0 +1,52 @@
+#ifndef ATR_TOOLS_MQH
+#define ATR_TOOLS_MQH
+
+//+------------------------------------------------------------------+
+//| Calculate Average True Range (ATR)                               |
+//| input:  rates[] - price series                                   |
+//|         period  - number of bars for ATR calculation             |
+//| output: ATR value                                                |
+//+------------------------------------------------------------------+
+double CalcATR(const MqlRates rates[], const int period)
+  {
+   if(ArraySize(rates)<=period)
+      return(0.0);
+   double sum = 0.0;
+   for(int i=0;i<period;i++)
+     {
+      double tr = rates[i].high - rates[i].low;
+      if(i+1 < ArraySize(rates))
+        {
+         double diff1 = MathAbs(rates[i].high - rates[i+1].close);
+         double diff2 = MathAbs(rates[i].low  - rates[i+1].close);
+         tr = MathMax(tr, MathMax(diff1,diff2));
+        }
+      sum += tr;
+     }
+   return(sum/period);
+  }
+
+//+------------------------------------------------------------------+
+//| Calculate standard deviation of closing prices                   |
+//| input:  rates[] - price series                                   |
+//|         period  - bars for calculation                            |
+//| output: standard deviation                                       |
+//+------------------------------------------------------------------+
+double CalcStdDev(const MqlRates rates[], const int period)
+  {
+   if(ArraySize(rates)<=period)
+      return(0.0);
+   double sum = 0.0;
+   for(int i=0;i<period;i++)
+      sum += rates[i].close;
+   double mean = sum/period;
+   double var = 0.0;
+   for(int i=0;i<period;i++)
+     {
+      double diff = rates[i].close - mean;
+      var += diff*diff;
+     }
+   return(MathSqrt(var/period));
+  }
+
+#endif // ATR_TOOLS_MQH

--- a/indicators/ma_slope.mqh
+++ b/indicators/ma_slope.mqh
@@ -1,0 +1,25 @@
+#ifndef MA_SLOPE_MQH
+#define MA_SLOPE_MQH
+
+//+------------------------------------------------------------------+
+//| Calculate slope of a simple moving average                        |
+//| input:  rates[] - price series                                    |
+//|         period  - number of bars for MA calculation               |
+//| output: difference between current MA and previous period MA      |
+//+------------------------------------------------------------------+
+double GetMASlope(const MqlRates rates[], const int period)
+  {
+   if(ArraySize(rates) <= period*2)
+      return(0.0);
+   double sum_recent = 0.0;
+   for(int i=0;i<period;i++)
+      sum_recent += rates[i].close;
+   double sum_prev = 0.0;
+   for(int i=period;i<period*2;i++)
+      sum_prev += rates[i].close;
+   double ma_recent = sum_recent/period;
+   double ma_prev   = sum_prev/period;
+   return(ma_recent - ma_prev);
+  }
+
+#endif // MA_SLOPE_MQH

--- a/indicators/regime_classifier.mqh
+++ b/indicators/regime_classifier.mqh
@@ -12,9 +12,9 @@ RegimeType DetectRegime(const RegimeFeature &feature)
   {
    if(feature.ob_retest)
       return(REGIME_TRAP);
-   if(feature.bos && feature.sweep && feature.volume_spike)
+   if(feature.bos && feature.sweep && feature.volume_spike && feature.atr>feature.stddev*2)
       return(REGIME_CHAOS);
-   if(feature.bos && !feature.sweep)
+   if(feature.bos && feature.ma_slope>0 && feature.rsi>60)
       return(REGIME_BREAKOUT);
    if(feature.range_compression && feature.volume_spike)
       return(REGIME_VOLATILE_RANGE);
@@ -24,7 +24,7 @@ RegimeType DetectRegime(const RegimeFeature &feature)
       return(REGIME_UPTREND);
    if(feature.trend_dir==TREND_DOWN && !feature.range_compression)
       return(REGIME_DOWNTREND);
-   if(feature.candle_strength==STRENGTH_NONE && !feature.volume_spike && feature.trend_dir==TREND_NONE)
+   if(feature.candle_strength==STRENGTH_NONE && !feature.volume_spike && feature.trend_dir==TREND_NONE && feature.atr<feature.stddev*0.5)
       return(REGIME_DRIFT);
    return(REGIME_UNKNOWN);
   }

--- a/indicators/rsi_tools.mqh
+++ b/indicators/rsi_tools.mqh
@@ -1,0 +1,30 @@
+#ifndef RSI_TOOLS_MQH
+#define RSI_TOOLS_MQH
+
+//+------------------------------------------------------------------+
+//| Calculate Relative Strength Index (RSI)                           |
+//| input:  rates[] - price series                                    |
+//|         period  - RSI period                                      |
+//| output: RSI value 0-100                                           |
+//+------------------------------------------------------------------+
+double GetRSI(const MqlRates rates[], const int period)
+  {
+   if(ArraySize(rates) <= period)
+      return(50.0);
+   double gain = 0.0;
+   double loss = 0.0;
+   for(int i=0;i<period;i++)
+     {
+      double diff = rates[i].close - rates[i+1].close;
+      if(diff>0)
+         gain += diff;
+      else
+         loss -= diff;
+     }
+   if(loss==0.0)
+      return(100.0);
+   double rs = gain / loss;
+   return(100.0 - (100.0/(1.0 + rs)));
+  }
+
+#endif // RSI_TOOLS_MQH

--- a/test/test_features_indicator.mq5
+++ b/test/test_features_indicator.mq5
@@ -5,6 +5,9 @@
 #include "..\\indicators\\sweep_detector.mqh"
 #include "..\\indicators\\mtf_signal.mqh"
 #include "..\\indicators\\mtf_tools.mqh"
+#include "..\\indicators\\atr_tools.mqh"
+#include "..\\indicators\\ma_slope.mqh"
+#include "..\\indicators\\rsi_tools.mqh"
 
 //+------------------------------------------------------------------+
 //| Helper assertion function                                        |
@@ -115,7 +118,45 @@ void TestGetMTFSignal()
    int expected = AggregateMTFSignal(htf, ltf, bars);
    int actual   = GetMTFSignal(rates, bars);
 
-   AssertEqual(true, expected==actual, "GetMTFSignal - cross timeframe signal");
+  AssertEqual(true, expected==actual, "GetMTFSignal - cross timeframe signal");
+ }
+
+//+------------------------------------------------------------------+
+//| Test CalcATR and CalcStdDev                                      |
+//+------------------------------------------------------------------+
+void TestATRStdDev()
+  {
+   MqlRates r[4];
+   ArraySetAsSeries(r,true);
+   r[0].high=1.20; r[0].low=1.10; r[0].close=1.15;
+   r[1].high=1.18; r[1].low=1.12; r[1].close=1.14;
+   r[2].high=1.19; r[2].low=1.11; r[2].close=1.13;
+   r[3].high=1.18; r[3].low=1.10; r[3].close=1.12;
+   double atr = CalcATR(r,2);
+   double stddev = CalcStdDev(r,3);
+   bool atr_ok = MathAbs(atr-0.08)<0.0001;
+   bool std_ok = MathAbs(stddev-0.011547)<0.001;
+   AssertEqual(true, atr_ok, "CalcATR basic");
+   AssertEqual(true, std_ok, "CalcStdDev basic");
+  }
+
+//+------------------------------------------------------------------+
+//| Test GetMASlope and GetRSI                                       |
+//+------------------------------------------------------------------+
+void TestMASlopeRSI()
+  {
+   MqlRates r[5];
+   ArraySetAsSeries(r,true);
+   r[0].close=12; r[1].close=11; r[2].close=10; r[3].close=9; r[4].close=8;
+   double slope = GetMASlope(r,2);
+   bool slope_ok = MathAbs(slope-2.0)<0.0001;
+   MqlRates rsiRates[5];
+   ArraySetAsSeries(rsiRates,true);
+   rsiRates[0].close=1.2; rsiRates[1].close=1.1; rsiRates[2].close=1.0; rsiRates[3].close=0.9; rsiRates[4].close=0.8;
+   double rsi = GetRSI(rsiRates,3);
+   bool rsi_ok = MathAbs(rsi-100.0)<0.1;
+   AssertEqual(true, slope_ok, "GetMASlope positive");
+   AssertEqual(true, rsi_ok, "GetRSI uptrend");
   }
 
 //+------------------------------------------------------------------+
@@ -128,6 +169,8 @@ int OnStart()
   TestDetectVolumeSpike();
   TestDetectSweep();
   TestGetMTFSignal();
+  TestATRStdDev();
+  TestMASlopeRSI();
   return(0);
   }
 

--- a/test/test_regime_classifier.mq5
+++ b/test/test_regime_classifier.mq5
@@ -36,30 +36,36 @@ void TestDetectRegime()
    f.volume_spike=true;
    AssertEqual(REGIME_VOLATILE_RANGE,DetectRegime(f),"DetectRegime volatile range");
 
-   // breakout
-   ResetRegimeFeature(f);
-   f.bos=true;
-   f.sweep=false;
-   AssertEqual(REGIME_BREAKOUT,DetectRegime(f),"DetectRegime breakout");
+  // breakout
+  ResetRegimeFeature(f);
+  f.bos=true;
+  f.sweep=false;
+  f.ma_slope=1.0;
+  f.rsi=70;
+  AssertEqual(REGIME_BREAKOUT,DetectRegime(f),"DetectRegime breakout");
 
    // trap
    ResetRegimeFeature(f);
    f.ob_retest=true;
    AssertEqual(REGIME_TRAP,DetectRegime(f),"DetectRegime trap");
 
-   // drift
-   ResetRegimeFeature(f);
-   f.trend_dir=TREND_NONE;
-   f.candle_strength=STRENGTH_NONE;
-   f.volume_spike=false;
-   AssertEqual(REGIME_DRIFT,DetectRegime(f),"DetectRegime drift");
+  // drift
+  ResetRegimeFeature(f);
+  f.trend_dir=TREND_NONE;
+  f.candle_strength=STRENGTH_NONE;
+  f.volume_spike=false;
+  f.atr=0.0005;
+  f.stddev=0.002;
+  AssertEqual(REGIME_DRIFT,DetectRegime(f),"DetectRegime drift");
 
-   // chaos
-   ResetRegimeFeature(f);
-   f.bos=true;
-   f.sweep=true;
-   f.volume_spike=true;
-   AssertEqual(REGIME_CHAOS,DetectRegime(f),"DetectRegime chaos");
+  // chaos
+  ResetRegimeFeature(f);
+  f.bos=true;
+  f.sweep=true;
+  f.volume_spike=true;
+  f.atr=0.02;
+  f.stddev=0.005;
+  AssertEqual(REGIME_CHAOS,DetectRegime(f),"DetectRegime chaos");
 
    // unknown
    ResetRegimeFeature(f);


### PR DESCRIPTION
## Summary
- add ATR, stddev, MA slope and RSI indicator modules
- capture these new metrics in `RegimeFeature`
- export additional metrics to CSV
- integrate indicators into `ProcessBar` and regime classification
- expand unit tests for new indicators and regime logic
- document new modules and fields in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cfb962bb083208425573ed7c118ce