### PR TITLE
Add indicator unit tests and mock ProcessBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ mt5_regime_detect/
 │   ├── exported_features.csv        # ไฟล์ export dataset
 ├── test/
 │   ├── test_features_indicator.mq5  # script/unit test function/indicator
+│   ├── test_indicator_math.mq5      # validate ATR/StdDev/RSI/MA slope
+│   ├── test_detect_regime_sets.mq5  # verify DetectRegime against preset cases
+│   ├── test_processbar_history.mq5  # history edge-case tests
+│   └── test_processbar_populate.mq5 # mock ProcessBar data population
 ├── docs/
 │   ├── data_dictionary.md           # อธิบาย field/format
 │   └── logic_note.md

--- a/test/test_detect_regime_sets.mq5
+++ b/test/test_detect_regime_sets.mq5
@@ -1,0 +1,50 @@
+#include "..\\EA\\features_struct.mqh"
+#include "..\\indicators\\regime_classifier.mqh"
+
+void AssertEqual(int expected,int actual,string message)
+{
+   if(expected==actual)
+      Print("PASS: ",message);
+   else
+      PrintFormat("FAIL: %s expected=%d actual=%d",message,expected,actual);
+}
+
+void TestDetectRegimeWithSets()
+{
+   RegimeFeature sets[8];
+   for(int i=0;i<8;i++)
+      ResetRegimeFeature(sets[i]);
+
+   sets[0].trend_dir=TREND_UP;                                     // UPTREND
+   sets[1].trend_dir=TREND_DOWN;                                   // DOWNTREND
+   sets[2].range_compression=true;                                 // STABLE_RANGE
+   sets[3].range_compression=true; sets[3].volume_spike=true;      // VOLATILE_RANGE
+   sets[4].bos=true; sets[4].ma_slope=1.0; sets[4].rsi=70;         // BREAKOUT
+   sets[5].ob_retest=true;                                         // TRAP
+   sets[6].candle_strength=STRENGTH_NONE; sets[6].volume_spike=false; sets[6].trend_dir=TREND_NONE; sets[6].atr=0.0005; sets[6].stddev=0.002; // DRIFT
+   sets[7].bos=true; sets[7].sweep=true; sets[7].volume_spike=true; sets[7].atr=0.02; sets[7].stddev=0.005; // CHAOS
+
+   int expected[8];
+   expected[0]=REGIME_UPTREND;
+   expected[1]=REGIME_DOWNTREND;
+   expected[2]=REGIME_STABLE_RANGE;
+   expected[3]=REGIME_VOLATILE_RANGE;
+   expected[4]=REGIME_BREAKOUT;
+   expected[5]=REGIME_TRAP;
+   expected[6]=REGIME_DRIFT;
+   expected[7]=REGIME_CHAOS;
+
+   for(int i=0;i<8;i++)
+   {
+      int actual=DetectRegime(sets[i]);
+      string msg=StringFormat("DetectRegime set %d",i);
+      AssertEqual(expected[i],actual,msg);
+   }
+}
+
+int OnStart()
+{
+   Print("Running DetectRegime set tests");
+   TestDetectRegimeWithSets();
+   return 0;
+}

--- a/test/test_indicator_math.mq5
+++ b/test/test_indicator_math.mq5
@@ -1,0 +1,64 @@
+#include "..\\EA\\features_struct.mqh"
+#include "..\\indicators\\atr_tools.mqh"
+#include "..\\indicators\\ma_slope.mqh"
+#include "..\\indicators\\rsi_tools.mqh"
+
+void AssertEqual(bool expected,bool actual,string msg)
+{
+   if(expected==actual)
+      Print("PASS: ",msg);
+   else
+      PrintFormat("FAIL: %s expected=%d actual=%d",msg,expected,actual);
+}
+
+void TestCalcATR()
+{
+   MqlRates r[3];
+   ArraySetAsSeries(r,true);
+   r[0].high=1.2; r[0].low=1.1; r[0].close=1.15;
+   r[1].high=1.19; r[1].low=1.11; r[1].close=1.14;
+   r[2].high=1.18; r[2].low=1.12; r[2].close=1.13;
+   double atr=CalcATR(r,2);
+   bool ok=MathAbs(atr-0.085)<=0.0001;
+   AssertEqual(true,ok,"CalcATR basic");
+}
+
+void TestCalcStdDev()
+{
+   MqlRates r[4];
+   ArraySetAsSeries(r,true);
+   r[0].close=1.0; r[1].close=1.1; r[2].close=0.9; r[3].close=1.0;
+   double sd=CalcStdDev(r,3);
+   bool ok=MathAbs(sd-0.1000)<=0.001;
+   AssertEqual(true,ok,"CalcStdDev basic");
+}
+
+void TestGetMASlope()
+{
+   MqlRates r[4];
+   ArraySetAsSeries(r,true);
+   r[0].close=5; r[1].close=4; r[2].close=3; r[3].close=2;
+   double slope=GetMASlope(r,2);
+   bool ok=MathAbs(slope-2.0)<=0.0001;
+   AssertEqual(true,ok,"GetMASlope basic");
+}
+
+void TestGetRSI()
+{
+   MqlRates r[5];
+   ArraySetAsSeries(r,true);
+   r[0].close=12; r[1].close=11; r[2].close=10; r[3].close=9; r[4].close=8;
+   double rsi=GetRSI(r,3);
+   bool ok=MathAbs(rsi-100.0)<=0.1;
+   AssertEqual(true,ok,"GetRSI strong trend");
+}
+
+int OnStart()
+{
+   Print("Running indicator math tests");
+   TestCalcATR();
+   TestCalcStdDev();
+   TestGetMASlope();
+   TestGetRSI();
+   return 0;
+}

--- a/test/test_processbar_populate.mq5
+++ b/test/test_processbar_populate.mq5
@@ -1,0 +1,82 @@
+// Mock CopyRates and CopyTickVolume before including EA
+MqlRates g_main[60];
+MqlRates g_htf[60];
+MqlRates g_ltf[60];
+long     g_vols[60];
+
+int MyCopyRates(string symbol,ENUM_TIMEFRAMES tf,int start_pos,int count,MqlRates& dest[])
+{
+   if(tf==PERIOD_H1)
+   {
+      ArrayResize(dest,count); for(int i=0;i<count;i++) dest[i]=g_htf[start_pos+i];
+      return count;
+   }
+   if(tf==PERIOD_M5)
+   {
+      ArrayResize(dest,count); for(int i=0;i<count;i++) dest[i]=g_ltf[start_pos+i];
+      return count;
+   }
+   ArrayResize(dest,count); for(int i=0;i<count;i++) dest[i]=g_main[start_pos+i];
+   return count;
+}
+
+int MyCopyTickVolume(string symbol,ENUM_TIMEFRAMES tf,int start_pos,int count,long& dest[])
+{
+   ArrayResize(dest,count); for(int i=0;i<count;i++) dest[i]=g_vols[start_pos+i];
+   return count;
+}
+
+#define CopyRates MyCopyRates
+#define CopyTickVolume MyCopyTickVolume
+#include "..\\EA\\RegimeMasterEA.mq5"
+
+void AssertEqual(bool expected,bool actual,string message)
+{
+   if(expected==actual)
+      Print("PASS: ",message);
+   else
+      PrintFormat("FAIL: %s expected=%d actual=%d",message,expected,actual);
+}
+
+void PrepareMockData()
+{
+   for(int i=0;i<60;i++)
+   {
+      double base=1.0 + i*0.01;
+      g_main[i].time = 1000-i*60;
+      g_main[i].open = base;
+      g_main[i].high = base+0.01;
+      g_main[i].low  = base-0.01;
+      g_main[i].close= base+0.005;
+      g_main[i].tick_volume=100+i;
+      g_htf[i]=g_main[i];
+      g_ltf[i]=g_main[i];
+      g_vols[i]=100+i;
+   }
+}
+
+void TestProcessBarPopulate()
+{
+   PrepareMockData();
+   RegimeFeature f;
+   ProcessBar(0,f);
+   double atr=CalcATR(g_main,14);
+   double stddev=CalcStdDev(g_main,14);
+   double slope=GetMASlope(g_main,10);
+   double rsi=GetRSI(g_main,14);
+   bool atr_ok=MathAbs(f.atr-atr)<=0.0001;
+   bool std_ok=MathAbs(f.stddev-stddev)<=0.0001;
+   bool slope_ok=MathAbs(f.ma_slope-slope)<=0.0001;
+   bool rsi_ok=MathAbs(f.rsi-rsi)<=0.0001;
+   AssertEqual(true,atr_ok,"ProcessBar ATR populated");
+   AssertEqual(true,std_ok,"ProcessBar StdDev populated");
+   AssertEqual(true,slope_ok,"ProcessBar MA slope populated");
+   AssertEqual(true,rsi_ok,"ProcessBar RSI populated");
+}
+
+int OnStart()
+{
+   Print("Running ProcessBar populate test");
+   TestProcessBarPopulate();
+   return 0;
+}


### PR DESCRIPTION
## Summary
- add indicator math tests for ATR/StdDev/RSI/MA slope
- verify DetectRegime against preset feature sets
- mock CopyRates in ProcessBar tests to check indicator fields
- list new scripts in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cfd320fb883208f3209fc9a4b3b20