### PR TITLE
Add BOS overlay indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mt5_regime_detect/
 │   ├── features_struct.mqh          # struct RegimeFeature, type ต่างๆ
 │   └── ExportUtils.mqh              # function ช่วย export csv/json, log
 ├── indicators/
-│   ├── bos_detector.mqh             # logic หา BOS
+│   ├── bos_detector.mqh             # logic หา BOS + overlay เส้น/ลูกศร
 │   ├── sweep_detector.mqh           # logic sweep
 │   ├── volume_tools.mqh             # logic volume spike/divergent
 │   ├── ob_retest.mqh                # logic OB retest/trap


### PR DESCRIPTION
## Summary
- draw swing levels and BOS arrows optionally in `bos_detector.mqh`
- describe the overlay in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d07af13d08320bb4c5f8a8d3b2179