### PR TITLE
Add volume subwindow indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ mt5_regime_detect/
 │   ├── bos_detector.mqh             # logic หา BOS + overlay เส้น/ลูกศร
 │   ├── sweep_detector.mqh           # logic sweep
 │   ├── volume_tools.mqh             # logic volume spike/divergent
+│   ├── volume_display.mqh           # subwindow volume chart with spike/divergence highlight
 │   ├── ob_retest.mqh                # logic OB retest/trap
 │   ├── candle_momentum.mqh          # logic candle strength/direction
 │   ├── session_tools.mqh            # logic session/context

--- a/indicators/volume_display.mqh
+++ b/indicators/volume_display.mqh
@@ -1,0 +1,66 @@
+#ifndef VOLUME_DISPLAY_MQH
+#define VOLUME_DISPLAY_MQH
+
+#include "volume_tools.mqh"
+
+#ifdef VOLUME_DISPLAY_INDICATOR
+
+#property indicator_separate_window
+#property indicator_buffers 2
+#property indicator_plots   1
+#property indicator_type1   DRAW_COLOR_HISTOGRAM
+#property indicator_label1  "Volume"
+
+input double InpSpikeThreshold = 1.5;         // volume spike multiplier
+input color  InpDefaultColor   = clrGray;     // normal bar color
+input color  InpSpikeColor     = clrRed;      // spike bar color
+input color  InpDivergeColor   = clrDeepPink; // divergence bar color
+
+double g_vol_buffer[];
+color  g_color_buffer[];
+
+int OnInit()
+  {
+   SetIndexBuffer(0,g_vol_buffer,INDICATOR_DATA);
+   SetIndexBuffer(1,g_color_buffer,INDICATOR_COLOR_INDEX);
+   PlotIndexSetInteger(0,PLOT_DRAW_TYPE,DRAW_COLOR_HISTOGRAM);
+   PlotIndexSetString(0,PLOT_LABEL,"Volume");
+   return(INIT_SUCCEEDED);
+  }
+
+int OnCalculate(const int rates_total,
+                const int prev_calculated,
+                const datetime &time[],
+                const double &open[],
+                const double &high[],
+                const double &low[],
+                const double &close[],
+                const long &tick_volume[],
+                const long &volume[],
+                const int &spread[])
+  {
+   int start = (prev_calculated==0) ? 0 : prev_calculated-1;
+   for(int bar=start; bar<rates_total-1; bar++)
+     {
+      g_vol_buffer[bar] = (double)tick_volume[bar];
+      g_color_buffer[bar] = InpDefaultColor;
+
+      bool spike = DetectVolumeSpike(tick_volume, bar, InpSpikeThreshold);
+      bool div   = false;
+      if(bar+1 < rates_total)
+        {
+         double price_delta = close[bar] - close[bar+1];
+         long   vol_delta   = tick_volume[bar] - tick_volume[bar+1];
+         div = ((price_delta>0 && vol_delta<0) || (price_delta<0 && vol_delta>0));
+        }
+      if(div)
+         g_color_buffer[bar] = InpDivergeColor;
+      else if(spike)
+         g_color_buffer[bar] = InpSpikeColor;
+     }
+   return(rates_total);
+  }
+
+#endif // VOLUME_DISPLAY_INDICATOR
+
+#endif // VOLUME_DISPLAY_MQH


### PR DESCRIPTION
## Summary
- add a new indicator `volume_display.mqh` showing tick volume in a subwindow
- highlight spike and divergence bars in different colors
- document the new indicator in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d086bb9248320a4f012ebac981ef6