### PR TITLE
Add order block rectangle overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ mt5_regime_detect/
 │   ├── sweep_detector.mqh           # logic sweep
 │   ├── volume_tools.mqh             # logic volume spike/divergent
 │   ├── volume_display.mqh           # subwindow volume chart with spike/divergence highlight
-│   ├── ob_retest.mqh                # logic OB retest/trap
+│   ├── ob_retest.mqh                # logic OB retest/trap + overlay rectangle highlight (width/color adjustable)
 │   ├── candle_momentum.mqh          # logic candle strength/direction
 │   ├── session_tools.mqh            # logic session/context
 │   ├── atr_tools.mqh                # ATR & StdDev calculations + overlay indicator


### PR DESCRIPTION
## Summary
- add overlay indicator to `ob_retest.mqh` for drawing order block rectangles and retest arrows
- expose color and width inputs
- document the new overlay in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d09446d1483209a6cfc160588da90