### PR TITLE
Add candle momentum overlay indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ mt5_regime_detect/
 │   ├── volume_tools.mqh             # logic volume spike/divergent
 │   ├── volume_display.mqh           # subwindow volume chart with spike/divergence highlight
 │   ├── ob_retest.mqh                # logic OB retest/trap + overlay rectangle highlight (width/color adjustable)
-│   ├── candle_momentum.mqh          # logic candle strength/direction
+│   ├── candle_momentum.mqh          # logic candle strength/direction + overlay icons (define CANDLE_MOMENTUM_OVERLAY_INDICATOR)
 │   ├── session_tools.mqh            # logic session/context
 │   ├── atr_tools.mqh                # ATR & StdDev calculations + overlay indicator
 │   ├── ma_slope.mqh                 # moving average slope

--- a/indicators/candle_momentum.mqh
+++ b/indicators/candle_momentum.mqh
@@ -43,4 +43,76 @@ CandleDirection GetCandleDirection(const MqlRates rates[], const int shift)
    return(DIR_NONE);
   }
 
+#ifdef CANDLE_MOMENTUM_OVERLAY_INDICATOR
+
+#property indicator_chart_window
+#property indicator_buffers 0
+
+input color  InpStrongColor = clrLime;        // arrow color for strong candles
+input color  InpWeakColor   = clrOrange;      // arrow color for weak candles
+input ENUM_ARROW_SYMBOL InpBullArrow = SYMBOL_ARROWUP;   // bull direction icon
+input ENUM_ARROW_SYMBOL InpBearArrow = SYMBOL_ARROWDOWN; // bear direction icon
+input bool   InpShowWeak   = true;           // display weak candles
+input bool   InpShowStrong = true;           // display strong candles
+input double InpYOffset    = 0.0;            // vertical offset in price
+
+int OnInit()
+  {
+   return(INIT_SUCCEEDED);
+  }
+
+int OnCalculate(const int rates_total,
+                const int prev_calculated,
+                const datetime &time[],
+                const double &open[],
+                const double &high[],
+                const double &low[],
+                const double &close[],
+                const long &tick_volume[],
+                const long &volume[],
+                const int &spread[])
+  {
+   int start=(prev_calculated==0)?0:prev_calculated-1;
+   for(int bar=start; bar<rates_total; bar++)
+     {
+      double body=MathAbs(close[bar]-open[bar]);
+      double range=high[bar]-low[bar];
+      CandleStrength strength=STRENGTH_NONE;
+      if(range>0.0)
+        {
+         double ratio=body/range;
+         if(ratio>0.6)
+            strength=STRENGTH_STRONG;
+         else if(ratio>0.3)
+            strength=STRENGTH_WEAK;
+        }
+      if(strength==STRENGTH_NONE)
+         continue;
+      if(strength==STRENGTH_WEAK && !InpShowWeak)
+         continue;
+      if(strength==STRENGTH_STRONG && !InpShowStrong)
+         continue;
+
+      double diff=close[bar]-open[bar];
+      CandleDirection dir=DIR_NONE;
+      if(diff>0) dir=DIR_BULL;
+      else if(diff<0) dir=DIR_BEAR;
+      if(dir==DIR_NONE)
+         continue;
+
+      string name=StringFormat("cm_arrow_%d",bar);
+      ENUM_ARROW_SYMBOL arrow=(dir==DIR_BULL)?InpBullArrow:InpBearArrow;
+      color c=(strength==STRENGTH_STRONG)?InpStrongColor:InpWeakColor;
+      double price=high[bar]+InpYOffset;
+      if(ObjectFind(0,name)<0)
+         ObjectCreate(0,name,OBJ_ARROW,0,time[bar],price);
+      ObjectSetInteger(0,name,OBJPROP_ARROWCODE,arrow);
+      ObjectSetInteger(0,name,OBJPROP_COLOR,c);
+      ObjectSetDouble(0,name,OBJPROP_PRICE,price);
+     }
+   return(rates_total);
+  }
+
+#endif // CANDLE_MOMENTUM_OVERLAY_INDICATOR
+
 #endif // CANDLE_MOMENTUM_MQH


### PR DESCRIPTION
## Summary
- overlay candle momentum icons on chart
- expose user controls to show weak/strong candles
- document overlay in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d0abe0a8883208d084b279a2675fb