### PR TITLE
Add MA slope display indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mt5_regime_detect/
 │   ├── session_display.mqh          # overlay session zones + news icon (define SESSION_DISPLAY_INDICATOR)
 │   ├── atr_tools.mqh                # ATR & StdDev calculations + overlay indicator
 │   ├── stddev_display.mqh           # subwindow StdDev line with threshold alert (define STDDEV_DISPLAY_INDICATOR)
-│   ├── ma_slope.mqh                 # moving average slope
+│   ├── ma_slope.mqh                 # moving average slope + overlay display (define MA_SLOPE_DISPLAY_INDICATOR)
 │   ├── rsi_tools.mqh                # RSI indicator
 │   └── regime_classifier.mqh        # classify market regime
 ├── data/

--- a/indicators/ma_slope.mqh
+++ b/indicators/ma_slope.mqh
@@ -22,4 +22,61 @@ double GetMASlope(const MqlRates rates[], const int period)
    return(ma_recent - ma_prev);
   }
 
+#ifdef MA_SLOPE_DISPLAY_INDICATOR
+
+#property indicator_chart_window
+#property indicator_buffers 3
+#property indicator_plots   1
+#property indicator_type1   DRAW_COLOR_LINE
+#property indicator_label1  "MA"
+
+input int   InpMAPeriod      = 20;          // moving average period
+input color InpUpColor       = clrLime;     // positive slope color
+input color InpDownColor     = clrRed;      // negative slope color
+
+double g_ma_buffer[];
+double g_color_buffer[];
+double g_slope_buffer[];
+int    g_ma_handle = INVALID_HANDLE;
+
+int OnInit()
+  {
+   SetIndexBuffer(0,g_ma_buffer,INDICATOR_DATA);
+   SetIndexBuffer(1,g_color_buffer,INDICATOR_COLOR_INDEX);
+   SetIndexBuffer(2,g_slope_buffer,INDICATOR_DATA);
+   PlotIndexSetString(0,PLOT_LABEL,"MA");
+   PlotIndexSetInteger(0,PLOT_LINE_COLOR,InpUpColor);
+
+   g_ma_handle = iMA(_Symbol,_Period,InpMAPeriod,0,MODE_SMA,PRICE_CLOSE);
+   return(INIT_SUCCEEDED);
+  }
+
+int OnCalculate(const int rates_total,
+                const int prev_calculated,
+                const datetime &time[],
+                const double &open[],
+                const double &high[],
+                const double &low[],
+                const double &close[],
+                const long &tick_volume[],
+                const long &volume[],
+                const int &spread[])
+  {
+   int start = prev_calculated==0 ? 0 : prev_calculated-1;
+   if(CopyBuffer(g_ma_handle,0,start,rates_total-start,g_ma_buffer)<=0)
+      return(0);
+
+   for(int i=start;i<rates_total;i++)
+     {
+      if(i+1<rates_total)
+         g_slope_buffer[i] = g_ma_buffer[i] - g_ma_buffer[i+1];
+      else
+         g_slope_buffer[i] = 0.0;
+      g_color_buffer[i] = (g_slope_buffer[i]>=0.0) ? InpUpColor : InpDownColor;
+     }
+   return(rates_total);
+  }
+
+#endif // MA_SLOPE_DISPLAY_INDICATOR
+
 #endif // MA_SLOPE_MQH


### PR DESCRIPTION
## Summary
- extend `ma_slope.mqh` with optional overlay indicator
- document indicator macro in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d0e15cc10832089c4961751257899