### PR TITLE
Include features struct in indicators

### DIFF
--- a/EA/ExportUtils.mqh
+++ b/EA/ExportUtils.mqh
@@ -3,6 +3,7 @@
 
 #include <Files\Csv.mqh>
 #include <stdlib.mqh>
+#include "features_struct.mqh"
 
 //+------------------------------------------------------------------+
 //| Export RegimeFeature data to CSV file                            |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ mt5_regime_detect/
 │   ├── mtf_signal_display.mqh        # overlay bitmask from MTF signal (define MTF_SIGNAL_DISPLAY_INDICATOR)
 │   ├── regime_display.mqh            # show RegimeType label on chart (define REGIME_DISPLAY_INDICATOR)
 │   └── regime_classifier.mqh        # classify market regime
+│   # indicator modules now include "..\\EA\\features_struct.mqh" for shared enums
 ├── data/
 │   ├── exported_features.csv        # ไฟล์ export dataset
 ├── test/

--- a/indicators/bos_detector.mqh
+++ b/indicators/bos_detector.mqh
@@ -1,6 +1,8 @@
 #ifndef BOS_DETECTOR_MQH
 #define BOS_DETECTOR_MQH
 
+#include "..\\EA\\features_struct.mqh"
+
 //+------------------------------------------------------------------+
 //| Return true if Break of Structure detected on given bar          |
 //| input:  rates[] - array of price data                             |

--- a/indicators/candle_momentum.mqh
+++ b/indicators/candle_momentum.mqh
@@ -1,6 +1,8 @@
 #ifndef CANDLE_MOMENTUM_MQH
 #define CANDLE_MOMENTUM_MQH
 
+#include "..\\EA\\features_struct.mqh"
+
 //+------------------------------------------------------------------+
 //| Calculate candle momentum strength                               |
 //| input:  rates[] - price series                                    |

--- a/indicators/mtf_tools.mqh
+++ b/indicators/mtf_tools.mqh
@@ -3,6 +3,7 @@
 
 #include "bos_detector.mqh"
 #include "volume_tools.mqh"
+#include "..\\EA\\features_struct.mqh"
 
 //+------------------------------------------------------------------+
 //| Calculate aggregated multi time frame signal                     |

--- a/indicators/session_tools.mqh
+++ b/indicators/session_tools.mqh
@@ -1,6 +1,8 @@
 #ifndef SESSION_TOOLS_MQH
 #define SESSION_TOOLS_MQH
 
+#include "..\\EA\\features_struct.mqh"
+
 //+------------------------------------------------------------------+
 //| Determine current market session from time                       |
 //| input:  time - timestamp to evaluate                              |


### PR DESCRIPTION
## Summary
- include `features_struct.mqh` across indicator modules and ExportUtils
- note in README about shared struct include

## Testing
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684d2b2c3b2c8320b6f7c70e6a3c1006