### PR TITLE
Fix JSON export append behavior

### DIFF
--- a/EA/ExportUtils.mqh
+++ b/EA/ExportUtils.mqh
@@ -55,9 +55,10 @@ void ExportFeatureJSON(const RegimeFeature &feature)
                            (int)feature.news_flag,
                            feature.mtf_signal,
                            (int)feature.regime);
-   int handle=FileOpen("data\\exported_features.json",FILE_WRITE|FILE_TXT|FILE_ANSI|FILE_APPEND);
+   int handle=FileOpen("data\\exported_features.json",FILE_READ|FILE_WRITE|FILE_TXT|FILE_ANSI);
    if(handle!=INVALID_HANDLE)
      {
+      FileSeek(handle,0,SEEK_END);
       FileWrite(handle,json);
       FileClose(handle);
      }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
     - Export dataset ทุกฟีเจอร์ (field ครบ) ไว้ใน `data/exported_features.csv`
       โดยไฟล์จะถูกเปิดแบบ append เพื่อไม่ลบทับข้อมูลเดิม
+    - JSON export จะบันทึกลง `data/exported_features.json` แบบต่อท้ายไฟล์เดิมเช่นกัน
     - รองรับ feed ไป GPT/ML/Automation ภายนอก
     - มี `control_panel.mqh` ให้ดูค่าฟีเจอร์ล่าสุดและกด toggle export ON/OFF
 


### PR DESCRIPTION
## Summary
- ensure JSON export uses read/write mode and seeks to EOF before writing
- document that JSON export appends to the existing file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3438a178832098a8839701209817