### PR TITLE
Add MT5 setup notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@
 
 ---
 
+## 🛠 **Setup in MetaTrader 5**
+
+Place the entire `EA/` directory and the `indicators/` folder inside your terminal's `MQL5/Experts` directory.
+
+```plaintext
+MQL5/Experts/
+├── EA/
+│   └── RegimeMasterEA.mq5
+└── indicators/
+    ├── atr_tools.mqh
+    └── ...
+```
+
+All `.mqh` files in `indicators/` are included by `RegimeMasterEA.mq5` using relative paths such as `..\indicators\atr_tools.mqh`. Keep this layout exactly as shipped.
+
+Missing files will produce "undeclared identifier" errors when functions like `CalcATR` or `DetectBOS` are referenced.
 ## 🧩 **Project Structure**
 
 ```plaintext


### PR DESCRIPTION
## Summary
- document how to place EA/ and indicators/ under **MQL5/Experts**
- warn that all indicator includes must stay relative to `RegimeMasterEA.mq5`
- mention compilation errors if files are missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d34b2d5e08320b75ba772878484c7