### PR TITLE
Fix ATR tools const parameter error

### DIFF
--- a/indicators/atr_tools.mqh
+++ b/indicators/atr_tools.mqh
@@ -7,7 +7,7 @@
 //|         period  - number of bars for ATR calculation             |
 //| output: ATR value                                                |
 //+------------------------------------------------------------------+
-double CalcATR(const MqlRates rates[], const int period)
+double CalcATR(const MqlRates &rates[], const int period)
   {
    if(ArraySize(rates)<=period)
       return(0.0);
@@ -32,7 +32,7 @@ double CalcATR(const MqlRates rates[], const int period)
 //|         period  - bars for calculation                            |
 //| output: standard deviation                                       |
 //+------------------------------------------------------------------+
-double CalcStdDev(const MqlRates rates[], const int period)
+double CalcStdDev(const MqlRates &rates[], const int period)
   {
    if(ArraySize(rates)<=period)
       return(0.0);


### PR DESCRIPTION
## Summary
- fix `CalcATR` and `CalcStdDev` signatures so const arrays are passed by reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d36fafddc8320b162a77b44caf404