### PR TITLE
Unify MqlRates parameter style

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Reference all structure/logic/rules/flow จากไฟล์นี้
 
 ทุกการ export, validate, integration — ให้ยึด logic+format ตามที่นิยามไว้ตรงนี้
 
+ใช้ parameter รูปแบบ `const MqlRates &rates[]` ในฟังก์ชัน indicator ให้เหมือนกันทุกไฟล์
+
 ถาม/Generate code อะไร — ให้ refer “README.md” repo นี้เป็น base context เสมอ
 
 🏆 Goal

--- a/indicators/bos_detector.mqh
+++ b/indicators/bos_detector.mqh
@@ -9,7 +9,7 @@
 //|         shift   - bar index to evaluate                           |
 //| output: true if BOS pattern found                                 |
 //+------------------------------------------------------------------+
-bool DetectBOS(const MqlRates rates[], const int shift)
+bool DetectBOS(const MqlRates &rates[], const int shift)
   {
    const int window = 3;
    if(shift + window >= ArraySize(rates))
@@ -36,7 +36,7 @@ bool DetectBOS(const MqlRates rates[], const int shift)
 //|         bars    - number of previous bars to check               |
 //| output: true if BOS pattern detected                             |
 //+------------------------------------------------------------------+
-bool DetectBOSLookback(const MqlRates rates[], const int bars)
+bool DetectBOSLookback(const MqlRates &rates[], const int bars)
   {
    //--- ensure enough bars are available
    if(bars<=0 || ArraySize(rates)<=bars)
@@ -103,7 +103,7 @@ bool DetectBOS(const double &high[],  // high price series
 //|         bars    - number of bars to analyze                       |
 //| output: TrendDirection enumeration value                          |
 //+------------------------------------------------------------------+
-TrendDirection GetTrendDirection(const MqlRates rates[], const int bars)
+TrendDirection GetTrendDirection(const MqlRates &rates[], const int bars)
   {
    if(bars<=0 || ArraySize(rates)<=bars)
       return(TREND_NONE);

--- a/indicators/candle_momentum.mqh
+++ b/indicators/candle_momentum.mqh
@@ -9,7 +9,7 @@
 //|         shift   - bar index                                       |
 //| output: CandleStrength value                                      |
 //+------------------------------------------------------------------+
-CandleStrength GetCandleStrength(const MqlRates rates[], const int shift)
+CandleStrength GetCandleStrength(const MqlRates &rates[], const int shift)
   {
    if(shift>=ArraySize(rates))
       return(STRENGTH_NONE);
@@ -33,7 +33,7 @@ CandleStrength GetCandleStrength(const MqlRates rates[], const int shift)
 //|         shift   - bar index                                       |
 //| output: CandleDirection value                                     |
 //+------------------------------------------------------------------+
-CandleDirection GetCandleDirection(const MqlRates rates[], const int shift)
+CandleDirection GetCandleDirection(const MqlRates &rates[], const int shift)
   {
    if(shift>=ArraySize(rates))
       return(DIR_NONE);

--- a/indicators/ma_slope.mqh
+++ b/indicators/ma_slope.mqh
@@ -7,7 +7,7 @@
 //|         period  - number of bars for MA calculation               |
 //| output: difference between current MA and previous period MA      |
 //+------------------------------------------------------------------+
-double GetMASlope(const MqlRates rates[], const int period)
+double GetMASlope(const MqlRates &rates[], const int period)
   {
    if(ArraySize(rates) <= period*2)
       return(0.0);

--- a/indicators/mtf_signal.mqh
+++ b/indicators/mtf_signal.mqh
@@ -7,7 +7,7 @@
 //|         bars    - number of bars to analyze                      |
 //| output: integer signal code                                      |
 //+------------------------------------------------------------------+
-int GetMTFSignal(const MqlRates rates[], const int bars)
+int GetMTFSignal(const MqlRates &rates[], const int bars)
   {
    //--- gather higher and lower timeframe data
    MqlRates htf[];                     // H1 timeframe for broader trend/BOS

--- a/indicators/ob_retest.mqh
+++ b/indicators/ob_retest.mqh
@@ -7,7 +7,7 @@
 //|         shift   - bar index to evaluate                           |
 //| output: true if retest pattern found                              |
 //+------------------------------------------------------------------+
-bool DetectOBRetest(const MqlRates rates[], const int shift)
+bool DetectOBRetest(const MqlRates &rates[], const int shift)
   {
    if(shift+1>=ArraySize(rates))
       return(false);
@@ -24,7 +24,7 @@ bool DetectOBRetest(const MqlRates rates[], const int shift)
 //|         bars    - analysis window                                 |
 //| output: true if trap zone detected                                |
 //+------------------------------------------------------------------+
-bool DetectTrapZone(const MqlRates rates[], const int bars)
+bool DetectTrapZone(const MqlRates &rates[], const int bars)
   {
    if(bars<=0 || ArraySize(rates)<=bars)
       return(false);

--- a/indicators/rsi_tools.mqh
+++ b/indicators/rsi_tools.mqh
@@ -7,7 +7,7 @@
 //|         period  - RSI period                                      |
 //| output: RSI value 0-100                                           |
 //+------------------------------------------------------------------+
-double GetRSI(const MqlRates rates[], const int period)
+double GetRSI(const MqlRates &rates[], const int period)
   {
    if(ArraySize(rates) <= period)
       return(50.0);

--- a/indicators/sweep_detector.mqh
+++ b/indicators/sweep_detector.mqh
@@ -7,7 +7,7 @@
 //|         shift   - bar index to evaluate                           |
 //| output: true if sweep pattern detected                            |
 //+------------------------------------------------------------------+
-bool DetectSweep(const MqlRates rates[], const int shift)
+bool DetectSweep(const MqlRates &rates[], const int shift)
   {
    if(shift>=ArraySize(rates))
       return(false);
@@ -24,7 +24,7 @@ bool DetectSweep(const MqlRates rates[], const int shift)
 //|         bars    - bars to evaluate                                |
 //| output: true if compression detected                              |
 //+------------------------------------------------------------------+
-bool DetectRangeCompression(const MqlRates rates[], const int bars)
+bool DetectRangeCompression(const MqlRates &rates[], const int bars)
   {
    if(bars<=0 || ArraySize(rates)<=bars)
       return(false);
@@ -46,7 +46,7 @@ bool DetectRangeCompression(const MqlRates rates[], const int bars)
 //|         bars    - number of bars to analyze                      |
 //| output: true if sweep condition detected                         |
 //+------------------------------------------------------------------+
-bool DetectSweep(const MqlRates rates[], const int bars)
+bool DetectSweep(const MqlRates &rates[], const int bars)
   {
    //--- validate array size against requested lookback
    if(bars<=0 || ArraySize(rates)<=bars)

--- a/indicators/volume_tools.mqh
+++ b/indicators/volume_tools.mqh
@@ -19,7 +19,7 @@ bool DetectVolumeSpike(const long volumes[], const int shift)
 //|         shift     - bar index                                     |
 //| output: true if divergence found                                  |
 //+------------------------------------------------------------------+
-bool DetectVolumeDivergence(const long volumes[], const MqlRates prices[], const int shift)
+bool DetectVolumeDivergence(const long volumes[], const MqlRates &prices[], const int shift)
   {
    if(shift+1>=ArraySize(volumes) || shift+1>=ArraySize(prices))
       return(false);
@@ -65,7 +65,7 @@ bool DetectVolumeSpike(const long &volumes[],   // volume data
 //| output: true if spike detected on the current bar                |
 //| usage:  DetectVolumeSpike(rates,bars)                            |
 //+------------------------------------------------------------------+
-bool DetectVolumeSpike(const MqlRates rates[], const int bars)
+bool DetectVolumeSpike(const MqlRates &rates[], const int bars)
   {
    //--- validate history length
    if(bars<=0 || ArraySize(rates)<=bars)


### PR DESCRIPTION
## Summary
- use `const MqlRates &rates[]` references across indicator functions
- document the parameter style guideline in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3eb677588320877dd2b851b13691